### PR TITLE
adapt to new yr.no api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .vscode/
+*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog Q Applet Weather Forecast
 
+## Version 2.1.0 - November 3, 2022
+
+Re-factored to use the new JSON based api at yr.no instead of the deprecated XML api
+
 ## Version 2.0.4 - May 15, 2019
 
 Removed internet connection error

--- a/README.md
+++ b/README.md
@@ -30,6 +30,23 @@ the Q Desktop application (<https://www.daskeyboard.com/q>)
 
 - `yarn test`
 
+## Development
+
+### Das Keyboard Q Applets
+
+https://www.daskeyboard.io/applet-development/
+
+### yr.no
+
+https://developer.yr.no/doc/GettingStarted/
+
+### Run from command line
+
+- `node index.js dev { <configuration-data> } eg:`
+
+- `node index.js dev '{ "authorization": { "apiKey": "" }, "applet": { "user": { "cityId": "https://api.met.no/weatherapi/locationforecast/2.0/compact?lat=52.060669&lon=4.494025", "cityId_LABEL": "Zoetermeer, South Holland (Netherlands)", "units": "metric", "units_LABEL": "Metric" }, "defaults": {} }, "geometry": { "width": 4, "height": 1, "origin": { "x": 3, "y": 0 } } }'`
+
+
 ## Contributions
 
 Pull requests welcome.

--- a/index.js
+++ b/index.js
@@ -1,10 +1,6 @@
+const got = require('got');
 const fs = require('fs');
-const {
-  parseString
-} = require('xml2js');
-const moment = require('moment');
 const readline = require('readline');
-const request = require('request-promise');
 const q = require('daskeyboard-applet');
 const logger = q.logger;
 
@@ -62,13 +58,12 @@ async function loadCities() {
  */
 function processCities(lines) {
   const options = [];
-  for (line of lines) {
+  for (const line of lines) {
     const values = line.split("\t");
-    const url = values[17].trim() || values[16].trim() || values[15].trim();
-    const urlParts = url.split('//')[1].split('/');
+    const url = values[16].trim();
     options.push({
       key: url,
-      value: `${values[3]}, ${urlParts[3].replace(/_/g, ' ')} (${values[10]})`,
+      value: `${values[3]}, ${values[15].replace(/_/g, ' ')} (${values[10]})`,
     })
   }
 
@@ -76,25 +71,12 @@ function processCities(lines) {
 }
 
 /**
- * Retrieve forecast XML from the service
+ * Retrieve forecast JSON from the service
  * @param {String} forecastUrl 
  */
 async function retrieveForecast(forecastUrl) {
   logger.info("Getting forecast via URL: " + forecastUrl);
-  return request.get({
-    url: forecastUrl,
-    json: false
-  }).then(async body => {
-    return new Promise((resolve, reject) => {
-      parseString(body, function (err, result) {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(result);
-        }
-      });
-    });
-  });
+  return await got(forecastUrl).json();
 }
 
 /**
@@ -103,7 +85,6 @@ async function retrieveForecast(forecastUrl) {
 class Period {
   constructor({
     from,
-    to,
     number,
     symbol = {},
     precipitation = {},
@@ -114,7 +95,6 @@ class Period {
   }) {
 
     this.from = from;
-    this.to = to;
     this.number = number;
 
     this.symbol = symbol;
@@ -127,18 +107,22 @@ class Period {
 }
 
 Period.revive = function (json) {
-  const meta = json['$'];
+  let next = json.data.next_1_hours;
+  if (next === undefined) {
+    next = json.data.next_6_hours;
+  }
+  if (next === undefined) {
+    next = json.data.next_12_hours;
+  }
+  const details = json.data.instant.details;
   return new Period({
-    from: meta.from,
-    to: meta.to,
-    number: meta.period,
-
-    symbol: json.symbol[0]['$'],
-    precipitation: json.precipitation[0]['$'],
-    windDirection: json.windDirection[0]['$'],
-    windSpeed: json.windSpeed[0]['$'],
-    temperature: json.temperature[0]['$'],
-    pressure: json.pressure[0]['$'],
+    from: new Date(json.time),
+    symbol: next.summary.symbol_code,
+    precipitation: next.details.precipitation_amount,
+    windDirection: details.wind_from_direction,
+    windSpeed: details.wind_speed,
+    temperature: details.air_temperature,
+    pressure: details.air_pressure_at_sea_level
   });
 }
 
@@ -157,19 +141,21 @@ class Day {
  * @param {String} data 
  */
 function processForecast(data) {
-  const periods = data.weatherdata.forecast[0].tabular[0].time;
+  const periods = data.properties.timeseries;
   const days = [];
-  let currentDate = '';
+  let currentNumber = 1;
+  let currentDate = 0;
   let thisDay = null;
-  for (periodJson of periods) {
+  for (const periodJson of periods) {
     let period = Period.revive(periodJson);
-    let thisDate = period.from.split('T')[0];
+    period.number = currentNumber++;
+    let thisDate = period.from.getDate();
     if (thisDate !== currentDate) {
       currentDate = thisDate;
       if (thisDay) {
         days.push(thisDay);
       }
-      thisDay = new Day(thisDate, [period]);
+      thisDay = new Day(period.from, [period]);
     } else {
       thisDay.periods.push(period);
     }
@@ -177,6 +163,8 @@ function processForecast(data) {
     if (thisDay && thisDay.length) {
       days.push(thisDay)
     }
+
+    if (days.length >= 5) break;
   }
 
   return days;
@@ -187,39 +175,25 @@ function processForecast(data) {
  * @param {Day} day 
  */
 function choosePeriod(day) {
-  let periods = [...day.periods];
-  // strip the overnight period
-  if (periods.length === 4) {
-    periods = periods.slice(1);
+  const selectedPeriods = [];
+  const useEvening = day.periods[0].from.getHours() > 17;
+  for (const period of day.periods) {
+    // try to limit to 07.00 .. 18.00 hours
+    if (period.from.getHours() < 7) continue;
+    if (period.from.getHours() > 17 && !useEvening) break;
+    selectedPeriods.push(period);
   }
-
-  // strip the late night period
-  if (periods.length > 1) {
-    periods = periods.slice(0, periods.length - 1);
-  }
-
-  // if only one period, then we return it
-  if (periods.length === 1) {
-    return periods[0];
-  }
-
-  // return the period with more precipitation
-  return (periods[0].precipitation.value > periods[1].precipitation.value) ?
-    periods[0] : periods[1];
-}
-
-const periodNameMap = {
-  '0': 'Overnight',
-  '1': 'Morning',
-  '2': 'Afternoon',
-  '3': 'Evening',
+  // return the period with most precipitation
+  const rc = selectedPeriods.reduce((prev, current) => { return prev.precipitation > current.precipitation ? prev : current; });
+  logger.info(`${rc.from.getDate()}-${rc.from.getMonth()+1}-${rc.from.getFullYear()}: ${rc.symbol}`);
+  return rc;
 }
 
 function generatePeriodText(period, units) {
   const temperature = (units == Units.imperial) ?
-    Math.round(period.temperature.value * 1.8 + 32) + '°F' :
-    period.temperature.value + '°C';
-  return `${periodNameMap[period.number]}: ${period.symbol.name}, ${temperature}`;
+    Math.round(period.temperature * 1.8 + 32) + '°F' :
+    period.temperature + '°C';
+  return `${period.from.getHours().toString().padStart(2, '0')}:00 ${period.symbol}, ${temperature}`;
 }
 
 /**
@@ -227,7 +201,7 @@ function generatePeriodText(period, units) {
  * @param {Period} period 
  */
 function chooseColor(period) {
-  const text = period.symbol.name.toLowerCase();
+  const text = period.symbol.toLowerCase();
   if (text.includes('snow')) {
     return Colors.SNOW;
   } else if (text.includes('storm')) {
@@ -280,7 +254,7 @@ class WeatherForecast extends q.DesktopApp {
     const messages = [];
 
     for (let day of days) {
-      const dateMessage = `<div style="color: red;"><strong>${moment(day.date).format('dddd, MMMM Do')}:</strong></div>`;
+      const dateMessage = `<div style="color: red;"><strong>${day.date.toString()}:</strong></div>`;
       messages.push(dateMessage);
       messages.push(`<div>`);
       day.periods.forEach((period, index) => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daskeyboard-applet--weather-international",
   "displayName": "Weather - International",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "Displays weather forecast.",
   "longDescription": "Be aware of the upcoming storm, ice age or heat wave coming to your place with the Q Weather applet.",
   "officialProductName": "Weather - International",
@@ -30,8 +30,7 @@
   },
   "dependencies": {
     "daskeyboard-applet": "2.11.3",
-    "moment": "^2.22.2",
-    "xml2js": "^0.4.19"
+    "got": "^11.8.3"
   },
   "qConfig": {
     "geometry": {

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const t = require('../index');
-const forecastUrl = 'http://www.yr.no/place/Andorra/Encamp/Vila/forecast.xml';
+const forecastUrl = 'https://api.met.no/weatherapi/locationforecast/2.0/compact?lat=42.50779&lon=1.52109';
 const cityName = 'Austin, Texas (USA)';
 const maxResults = 1000;
 
@@ -21,9 +21,8 @@ describe('processCities', function () {
       const options = t.processCities(lines);
       assert.ok(options);
       assert(options.length > 1000);
-      assert.strictEqual('http://www.yr.no/place/Andorra/Andorra_la_Vella/Andorra_la_Vella/forecast.xml', options[0].key);
-      assert.strictEqual('Andorra la Vella, Andorra la_Vella (Andorra)', options[0].value);
-
+      assert.strictEqual('https://api.met.no/weatherapi/locationforecast/2.0/compact?lat=42.50779&lon=1.52109', options[0].key);
+      assert.strictEqual('Andorra la Vella, Andorra la Vella (Andorra)', options[0].value);
     });
   });
 });
@@ -32,72 +31,61 @@ describe('retrieveForecast', function () {
   it('retrieves a forecast', async function () {
     return t.retrieveForecast(forecastUrl).then(data => {
       assert.ok(data);
-      assert.ok(data.weatherdata.forecast);
-      assert(Array.isArray(data.weatherdata.forecast));
-      assert(Array.isArray(data.weatherdata.forecast[0].tabular));
-      assert.ok(data.weatherdata.forecast[0].tabular[0].time);
-      const period = data.weatherdata.forecast[0].tabular[0].time[0];
-      assert.ok(period);
+      assert.ok(data.properties);
+      assert(Array.isArray(data.properties.timeseries));
+      assert.ok(data.properties.timeseries[0]);
+      assert.ok(data.properties.timeseries[0].time);
+      assert.ok(data.properties.timeseries[0].data);
     })
   })
 })
 
 const testPeriodJson = {
-  "$": {
-    "from": "2018-11-28T21:00:00",
-    "to": "2018-11-29T00:00:00",
-    "period": "3"
-  },
-  "symbol": [{
-    "$": {
-      "number": "3",
-      "numberEx": "3",
-      "name": "Partly cloudy",
-      "var": "03n"
+  'time': '2022-11-04T16:00:00Z',
+  'data': {
+    'instant': {
+      'details': {
+        'air_pressure_at_sea_level': 1010.4,
+        'air_temperature': 10.5,
+        'cloud_area_fraction': 37.5,
+        'relative_humidity': 69.6,
+        'wind_from_direction': 326.7,
+        'wind_speed': 2.7
+      }
+    },
+    'next_12_hours': {
+      'summary': {
+        'symbol_code': 'fair_night'
+      }
+    },
+    'next_1_hours': {
+      'summary': {
+        'symbol_code': 'fair_night'
+      },
+      'details': {
+        'precipitation_amount': 0
+      }
+    },
+    'next_6_hours': {
+      'summary': {
+        'symbol_code': 'fair_night'
+      },
+      'details': {
+        'precipitation_amount': 0.1
+      }
     }
-  }],
-  "precipitation": [{
-    "$": {
-      "value": "0"
-    }
-  }],
-  "windDirection": [{
-    "$": {
-      "deg": "356.3",
-      "code": "N",
-      "name": "North"
-    }
-  }],
-  "windSpeed": [{
-    "$": {
-      "mps": "0.6",
-      "name": "Light air"
-    }
-  }],
-  "temperature": [{
-    "$": {
-      "unit": "celsius",
-      "value": "7"
-    }
-  }],
-  "pressure": [{
-    "$": {
-      "unit": "hPa",
-      "value": "1021.4"
-    }
-  }]
+  }
 }
+
 
 describe('Period', function () {
   it('revive(json)', function () {
     const period = t.Period.revive(testPeriodJson);
     assert.ok(period);
     assert.ok(period.from);
-    assert.ok(period.to);
-    assert.ok(period.number);
     assert.ok(period.symbol);
-    assert.ok(period.precipitation);
-    assert.ok(period.temperature);
+    assert.ok(period.precipitation !== undefined);
+    assert.ok(period.temperature !== undefined);
   })
 });
 
@@ -120,37 +108,27 @@ describe('processForecast', function () {
 describe('chooseColor', function () {
   it('picks snow', function () {
     assert.equal(t.Colors.SNOW, t.chooseColor(new t.Period({
-      symbol: {
-        name: 'Snow'
-      }
+      symbol: 'Snow'
     })));
   });
   it('picks storm', function () {
     assert.equal(t.Colors.STORM, t.chooseColor(new t.Period({
-      symbol: {
-        name: 'Stormy and Windy'
-      }
+      symbol: 'Stormy and Windy'
     })));
   });
   it('picks rain', function () {
     assert.equal(t.Colors.SHOWER, t.chooseColor(new t.Period({
-      symbol: {
-        name: 'Rain'
-      }
+      symbol: 'Rain'
     })));
   });
   it('picks clouds', function () {
     assert.equal(t.Colors.CLOUDY, t.chooseColor(new t.Period({
-      symbol: {
-        name: 'Cloudy and warm'
-      }
+      symbol: 'Cloudy and warm'
     })));
   });
   it('picks clear', function () {
     assert.equal(t.Colors.CLEAR, t.chooseColor(new t.Period({
-      symbol: {
-        name: 'Clear'
-      }
+      symbol: 'Clear'
     })));
   });
 });
@@ -158,48 +136,53 @@ describe('chooseColor', function () {
 
 describe('choosePeriod', function () {
   it('picks the only period', function () {
-    const period = new t.Period({
-      from: 'foo'
-    });
+    const period = {
+      from: new Date('2022-11-04T16:00:00.000Z'),
+      number: 8,
+      symbol: 'fair_night',
+      precipitation: 0,
+      windDirection: 326.7,
+      windSpeed: 2.7,
+      temperature: 10.5,
+      pressure: 1010.4
+    };
     const day = new t.Day('foo', [period]);
     const test = t.choosePeriod(day);
     assert.ok(test);
     assert.strictEqual(period.from, test.from)
   });
 
-  it('picks the first of two periods', function () {
-    const period1 = new t.Period({
-      from: 'foo'
-    });
-
-    const period2 = new t.Period({
-      from: 'bar'
-    });
-
-    const day = new t.Day('foo', [period1, period2]);
-    const test = t.choosePeriod(day);
-    assert.ok(test);
-    assert.strictEqual(period1.from, test.from)
-  });
-
   it('picks the rainiest of three periods', function () {
-    const period1 = new t.Period({
-      precipitation: {
-        value: '2.4'
-      }
-    });
-
-    const period2 = new t.Period({
-      precipitation: {
-        value: '4.4'
-      }
-    });
-
-    const period3 = new t.Period({
-      precipitation: {
-        value: '4.9'
-      }
-    });
+    const period1 = {
+      from: new Date('2022-11-04T12:00:00.000Z'),
+      number: 8,
+      symbol: 'fair_night',
+      precipitation: 2.4,
+      windDirection: 326.7,
+      windSpeed: 2.7,
+      temperature: 10.5,
+      pressure: 1010.4
+    };
+    const period2 = {
+      from: new Date('2022-11-04T13:00:00.000Z'),
+      number: 9,
+      symbol: 'fair_night',
+      precipitation: 4.4,
+      windDirection: 326.7,
+      windSpeed: 2.7,
+      temperature: 10.5,
+      pressure: 1010.4
+    };
+    const period3 = {
+      from: new Date('2022-11-04T14:00:00.000Z'),
+      number: 10,
+      symbol: 'fair_night',
+      precipitation: 4.9,
+      windDirection: 326.7,
+      windSpeed: 2.7,
+      temperature: 10.5,
+      pressure: 1010.4
+    };
 
     const day = new t.Day('foo', [period1, period2, period3]);
     const test = t.choosePeriod(day);
@@ -208,100 +191,69 @@ describe('choosePeriod', function () {
   });
 
   it('picks the rainiest of four periods', function () {
-    const period0 = new t.Period({
-      precipitation: {
-        value: '1.4'
-      }
-    });
+    const period1 = {
+      from: new Date('2022-11-04T12:00:00.000Z'),
+      number: 8,
+      symbol: 'fair_night',
+      precipitation: 1.4,
+      windDirection: 326.7,
+      windSpeed: 2.7,
+      temperature: 10.5,
+      pressure: 1010.4
+    };
+    const period2 = {
+      from: new Date('2022-11-04T13:00:00.000Z'),
+      number: 9,
+      symbol: 'fair_night',
+      precipitation: 6.4,
+      windDirection: 326.7,
+      windSpeed: 2.7,
+      temperature: 10.5,
+      pressure: 1010.4
+    };
+    const period3 = {
+      from: new Date('2022-11-04T14:00:00.000Z'),
+      number: 10,
+      symbol: 'fair_night',
+      precipitation: 4.4,
+      windDirection: 326.7,
+      windSpeed: 2.7,
+      temperature: 10.5,
+      pressure: 1010.4
+    };
+    const period4 = {
+      from: new Date('2022-11-04T14:00:00.000Z'),
+      number: 11,
+      symbol: 'fair_night',
+      precipitation: 4.9,
+      windDirection: 326.7,
+      windSpeed: 2.7,
+      temperature: 10.5,
+      pressure: 1010.4
+    };
 
-    const period1 = new t.Period({
-      precipitation: {
-        value: '6.4'
-      }
-    });
-
-    const period2 = new t.Period({
-      precipitation: {
-        value: '4.4'
-      }
-    });
-
-    const period3 = new t.Period({
-      precipitation: {
-        value: '4.9'
-      }
-    });
-
-    const day = new t.Day('foo', [period0, period1, period2, period3]);
+    const day = new t.Day('foo', [period1, period2, period3, period4]);
     const test = t.choosePeriod(day);
     assert.ok(test);
-    assert.strictEqual(period1.precipitation.value, test.precipitation.value);
+    assert.strictEqual(period2.precipitation.value, test.precipitation.value);
   });
 });
 
 describe('generatePeriodText', function () {
-  it('generates overnight text', function () {
+  it('generates text', function () {
     const text = t.generatePeriodText(new t.Period({
-      number: 0,
-      symbol: {
-        name: 'Cloudy'
-      },
-      temperature: {
-        unit: 'celsius',
-        value: '8'
-      }
+      from: new Date('2022-11-04T14:00:00.000Z'),
+      number: 11,
+      symbol: 'Cloudy',
+      precipitation: 4.9,
+      windDirection: 326.7,
+      windSpeed: 2.7,
+      temperature: 8,
+      pressure: 1010.4
     }))
 
     console.info(text);
-    assert.equal('Overnight: Cloudy, 8°C', text);
-  });
-
-  it('generates morning text', function () {
-    const text = t.generatePeriodText(new t.Period({
-      number: 1,
-      symbol: {
-        name: 'Cloudy'
-      },
-      temperature: {
-        unit: 'celsius',
-        value: '8'
-      }
-    }), t.Units.imperial);
-
-    console.info(text);
-    assert.equal('Morning: Cloudy, 46°F', text);
-  });
-
-  it('generates afternoon text', function () {
-    const text = t.generatePeriodText(new t.Period({
-      number: 2,
-      symbol: {
-        name: 'Cloudy'
-      },
-      temperature: {
-        unit: 'celsius',
-        value: '8'
-      }
-    }))
-
-    console.info(text);
-    assert.equal('Afternoon: Cloudy, 8°C', text);
-  });
-
-  it('generates evening text', function () {
-    const text = t.generatePeriodText(new t.Period({
-      number: 3,
-      symbol: {
-        name: 'Cloudy'
-      },
-      temperature: {
-        unit: 'celsius',
-        value: '8'
-      }
-    }), t.Units.imperial);
-
-    console.info(text);
-    assert.equal('Evening: Cloudy, 46°F', text);
+    assert.equal('15:00 Cloudy, 8°C', text);
   });
 });
 
@@ -309,172 +261,806 @@ describe('generatePeriodText', function () {
 describe('WeatherForecast', function () {
 
   const days = [
-    new t.Day('2018-11-30', [
+    new t.Day(4, [
       new t.Period({
-        number: 0,
-        symbol: {
-          name: 'Rain'
-        },
-        temperature: {
-          unit: 'celsius',
-          value: '8'
-        }
-      }),
-      new t.Period({
+        from: new Date('2022-11-04T13:00:00.000Z'),
+        to: new Date('2022-11-04T14:00:00.000Z'),
         number: 1,
-        symbol: {
-          name: 'Cloudy'
-        },
-        temperature: {
-          unit: 'celsius',
-          value: '9'
-        }
+        symbol: 'cloudy',
+        precipitation: 0,
+        windDirection: 329.3,
+        windSpeed: 1.9,
+        temperature: 11.6,
+        pressure: 1008.3
       }),
       new t.Period({
+        from: new Date('2022-11-04T14:00:00.000Z'),
+        to: new Date('2022-11-04T15:00:00.000Z'),
         number: 2,
-        symbol: {
-          name: 'Sunny'
-        },
-        temperature: {
-          unit: 'celsius',
-          value: '10'
-        }
+        symbol: 'cloudy',
+        precipitation: 0,
+        windDirection: 307.2,
+        windSpeed: 2.1,
+        temperature: 12.1,
+        pressure: 1008.9
       }),
       new t.Period({
+        from: new Date('2022-11-04T15:00:00.000Z'),
+        to: new Date('2022-11-04T16:00:00.000Z'),
         number: 3,
-        symbol: {
-          name: 'Cloudy'
-        },
-        temperature: {
-          unit: 'celsius',
-          value: '11'
-        }
+        symbol: 'cloudy',
+        precipitation: 0,
+        windDirection: 326.3,
+        windSpeed: 3.3,
+        temperature: 11.8,
+        pressure: 1009.6
+      }),
+      new t.Period({
+        from: new Date('2022-11-04T16:00:00.000Z'),
+        to: new Date('2022-11-04T17:00:00.000Z'),
+        number: 4,
+        symbol: 'partlycloudy_night',
+        precipitation: 0,
+        windDirection: 319.4,
+        windSpeed: 3.4,
+        temperature: 10.9,
+        pressure: 1010.5
+      }),
+      new t.Period({
+        from: new Date('2022-11-04T17:00:00.000Z'),
+        to: new Date('2022-11-04T18:00:00.000Z'),
+        number: 5,
+        symbol: 'fair_night',
+        precipitation: 0,
+        windDirection: 340.8,
+        windSpeed: 2.5,
+        temperature: 9.9,
+        pressure: 1011.3
+      }),
+      new t.Period({
+        from: new Date('2022-11-04T18:00:00.000Z'),
+        to: new Date('2022-11-04T19:00:00.000Z'),
+        number: 6,
+        symbol: 'partlycloudy_night',
+        precipitation: 0,
+        windDirection: 319.6,
+        windSpeed: 2.2,
+        temperature: 8.4,
+        pressure: 1011.9
+      }),
+      new t.Period({
+        from: new Date('2022-11-04T19:00:00.000Z'),
+        to: new Date('2022-11-04T20:00:00.000Z'),
+        number: 7,
+        symbol: 'partlycloudy_night',
+        precipitation: 0,
+        windDirection: 288.4,
+        windSpeed: 2.5,
+        temperature: 8.8,
+        pressure: 1012.7
+      }),
+      new t.Period({
+        from: new Date('2022-11-04T20:00:00.000Z'),
+        to: new Date('2022-11-04T21:00:00.000Z'),
+        number: 8,
+        symbol: 'partlycloudy_night',
+        precipitation: 0,
+        windDirection: 300.7,
+        windSpeed: 3,
+        temperature: 9,
+        pressure: 1013.4
+      }),
+      new t.Period({
+        from: new Date('2022-11-04T21:00:00.000Z'),
+        to: new Date('2022-11-04T22:00:00.000Z'),
+        number: 9,
+        symbol: 'rainshowers_night',
+        precipitation: 0.6,
+        windDirection: 276.4,
+        windSpeed: 2.2,
+        temperature: 8.3,
+        pressure: 1013.7
+      }),
+      new t.Period({
+        from: new Date('2022-11-04T22:00:00.000Z'),
+        to: new Date('2022-11-04T23:00:00.000Z'),
+        number: 10,
+        symbol: 'partlycloudy_night',
+        precipitation: 0,
+        windDirection: 270.6,
+        windSpeed: 1.9,
+        temperature: 7.8,
+        pressure: 1014.5
       })
     ]),
-    new t.Day('2018-12-01', [
+    new t.Day(5, [
       new t.Period({
-        number: 0,
-        symbol: {
-          name: 'Rain'
-        },
-        temperature: {
-          unit: 'celsius',
-          value: '8'
-        }
+        from: new Date('2022-11-04T23:00:00.000Z'),
+        to: new Date('2022-11-05T00:00:00.000Z'),
+        number: 11,
+        symbol: 'fair_night',
+        precipitation: 0,
+        windDirection: 250.4,
+        windSpeed: 2,
+        temperature: 7.9,
+        pressure: 1014.5
       }),
       new t.Period({
-        number: 1,
-        symbol: {
-          name: 'Cloudy'
-        },
-        temperature: {
-          unit: 'celsius',
-          value: '9'
-        }
+        from: new Date('2022-11-05T00:00:00.000Z'),
+        to: new Date('2022-11-05T01:00:00.000Z'),
+        number: 12,
+        symbol: 'fair_night',
+        precipitation: 0,
+        windDirection: 253.9,
+        windSpeed: 2,
+        temperature: 7.6,
+        pressure: 1014.6
       }),
       new t.Period({
-        number: 2,
-        symbol: {
-          name: 'Sunny'
-        },
-        temperature: {
-          unit: 'celsius',
-          value: '10'
-        }
+        from: new Date('2022-11-05T01:00:00.000Z'),
+        to: new Date('2022-11-05T02:00:00.000Z'),
+        number: 13,
+        symbol: 'clearsky_night',
+        precipitation: 0,
+        windDirection: 240.7,
+        windSpeed: 2.1,
+        temperature: 7.1,
+        pressure: 1014.7
       }),
       new t.Period({
-        number: 3,
-        symbol: {
-          name: 'Cloudy'
-        },
-        temperature: {
-          unit: 'celsius',
-          value: '11'
-        }
+        from: new Date('2022-11-05T02:00:00.000Z'),
+        to: new Date('2022-11-05T03:00:00.000Z'),
+        number: 14,
+        symbol: 'fair_night',
+        precipitation: 0,
+        windDirection: 221.4,
+        windSpeed: 2.2,
+        temperature: 6.7,
+        pressure: 1014.8
+      }),
+      new t.Period({
+        from: new Date('2022-11-05T03:00:00.000Z'),
+        to: new Date('2022-11-05T04:00:00.000Z'),
+        number: 15,
+        symbol: 'partlycloudy_night',
+        precipitation: 0,
+        windDirection: 221.6,
+        windSpeed: 2.6,
+        temperature: 7.2,
+        pressure: 1014.8
+      }),
+      new t.Period({
+        from: new Date('2022-11-05T04:00:00.000Z'),
+        to: new Date('2022-11-05T05:00:00.000Z'),
+        number: 16,
+        symbol: 'partlycloudy_night',
+        precipitation: 0,
+        windDirection: 242.5,
+        windSpeed: 3.5,
+        temperature: 8.2,
+        pressure: 1015.1
+      }),
+      new t.Period({
+        from: new Date('2022-11-05T05:00:00.000Z'),
+        to: new Date('2022-11-05T06:00:00.000Z'),
+        number: 17,
+        symbol: 'partlycloudy_night',
+        precipitation: 0,
+        windDirection: 237.9,
+        windSpeed: 3.9,
+        temperature: 8.4,
+        pressure: 1015.3
+      }),
+      new t.Period({
+        from: new Date('2022-11-05T06:00:00.000Z'),
+        to: new Date('2022-11-05T07:00:00.000Z'),
+        number: 18,
+        symbol: 'fair_night',
+        precipitation: 0,
+        windDirection: 229.4,
+        windSpeed: 3.4,
+        temperature: 8.6,
+        pressure: 1015.2
+      }),
+      new t.Period({
+        from: new Date('2022-11-05T07:00:00.000Z'),
+        to: new Date('2022-11-05T08:00:00.000Z'),
+        number: 19,
+        symbol: 'partlycloudy_day',
+        precipitation: 0,
+        windDirection: 237.6,
+        windSpeed: 3.5,
+        temperature: 8.7,
+        pressure: 1015.5
+      }),
+      new t.Period({
+        from: new Date('2022-11-05T08:00:00.000Z'),
+        to: new Date('2022-11-05T09:00:00.000Z'),
+        number: 20,
+        symbol: 'fair_day',
+        precipitation: 0,
+        windDirection: 234.8,
+        windSpeed: 4.1,
+        temperature: 9.8,
+        pressure: 1015.7
+      }),
+      new t.Period({
+        from: new Date('2022-11-05T09:00:00.000Z'),
+        to: new Date('2022-11-05T10:00:00.000Z'),
+        number: 21,
+        symbol: 'fair_day',
+        precipitation: 0,
+        windDirection: 234.8,
+        windSpeed: 4.9,
+        temperature: 10.8,
+        pressure: 1015.8
+      }),
+      new t.Period({
+        from: new Date('2022-11-05T10:00:00.000Z'),
+        to: new Date('2022-11-05T11:00:00.000Z'),
+        number: 22,
+        symbol: 'partlycloudy_day',
+        precipitation: 0,
+        windDirection: 244,
+        windSpeed: 5.8,
+        temperature: 11.8,
+        pressure: 1015.6
+      }),
+      new t.Period({
+        from: new Date('2022-11-05T11:00:00.000Z'),
+        to: new Date('2022-11-05T12:00:00.000Z'),
+        number: 23,
+        symbol: 'cloudy',
+        precipitation: 0,
+        windDirection: 229.6,
+        windSpeed: 5.4,
+        temperature: 12.2,
+        pressure: 1015.7
+      }),
+      new t.Period({
+        from: new Date('2022-11-05T12:00:00.000Z'),
+        to: new Date('2022-11-05T13:00:00.000Z'),
+        number: 24,
+        symbol: 'cloudy',
+        precipitation: 0,
+        windDirection: 228.4,
+        windSpeed: 5.7,
+        temperature: 12.1,
+        pressure: 1015.7
+      }),
+      new t.Period({
+        from: new Date('2022-11-05T13:00:00.000Z'),
+        to: new Date('2022-11-05T14:00:00.000Z'),
+        number: 25,
+        symbol: 'cloudy',
+        precipitation: 0,
+        windDirection: 224,
+        windSpeed: 5.8,
+        temperature: 12,
+        pressure: 1015.6
+      }),
+      new t.Period({
+        from: new Date('2022-11-05T14:00:00.000Z'),
+        to: new Date('2022-11-05T15:00:00.000Z'),
+        number: 26,
+        symbol: 'cloudy',
+        precipitation: 0,
+        windDirection: 225.4,
+        windSpeed: 5.5,
+        temperature: 12.1,
+        pressure: 1015.3
+      }),
+      new t.Period({
+        from: new Date('2022-11-05T15:00:00.000Z'),
+        to: new Date('2022-11-05T16:00:00.000Z'),
+        number: 27,
+        symbol: 'cloudy',
+        precipitation: 0,
+        windDirection: 206.3,
+        windSpeed: 5,
+        temperature: 11.6,
+        pressure: 1014.9
+      }),
+      new t.Period({
+        from: new Date('2022-11-05T16:00:00.000Z'),
+        to: new Date('2022-11-05T17:00:00.000Z'),
+        number: 28,
+        symbol: 'rain',
+        precipitation: 0.3,
+        windDirection: 202.1,
+        windSpeed: 5,
+        temperature: 10.8,
+        pressure: 1014.6
+      }),
+      new t.Period({
+        from: new Date('2022-11-05T17:00:00.000Z'),
+        to: new Date('2022-11-05T18:00:00.000Z'),
+        number: 29,
+        symbol: 'cloudy',
+        precipitation: 0,
+        windDirection: 201.5,
+        windSpeed: 5.6,
+        temperature: 10.7,
+        pressure: 1014.5
+      }),
+      new t.Period({
+        from: new Date('2022-11-05T18:00:00.000Z'),
+        to: new Date('2022-11-05T19:00:00.000Z'),
+        number: 30,
+        symbol: 'cloudy',
+        precipitation: 0,
+        windDirection: 199.7,
+        windSpeed: 6.1,
+        temperature: 10.4,
+        pressure: 1014.2
+      }),
+      new t.Period({
+        from: new Date('2022-11-05T19:00:00.000Z'),
+        to: new Date('2022-11-05T20:00:00.000Z'),
+        number: 31,
+        symbol: 'cloudy',
+        precipitation: 0,
+        windDirection: 197.9,
+        windSpeed: 6.3,
+        temperature: 10.5,
+        pressure: 1014.2
+      }),
+      new t.Period({
+        from: new Date('2022-11-05T20:00:00.000Z'),
+        to: new Date('2022-11-05T21:00:00.000Z'),
+        number: 32,
+        symbol: 'cloudy',
+        precipitation: 0,
+        windDirection: 195.4,
+        windSpeed: 6.8,
+        temperature: 10.5,
+        pressure: 1013.9
+      }),
+      new t.Period({
+        from: new Date('2022-11-05T21:00:00.000Z'),
+        to: new Date('2022-11-05T22:00:00.000Z'),
+        number: 33,
+        symbol: 'cloudy',
+        precipitation: 0,
+        windDirection: 196.8,
+        windSpeed: 7.1,
+        temperature: 10.4,
+        pressure: 1013.8
+      }),
+      new t.Period({
+        from: new Date('2022-11-05T22:00:00.000Z'),
+        to: new Date('2022-11-05T23:00:00.000Z'),
+        number: 34,
+        symbol: 'cloudy',
+        precipitation: 0,
+        windDirection: 198,
+        windSpeed: 7.2,
+        temperature: 10.4,
+        pressure: 1013.5
       })
     ]),
-    new t.Day('2018-12-02', [
+    new t.Day(6, [
       new t.Period({
-        number: 0,
-        symbol: {
-          name: 'Rain'
-        },
-        temperature: {
-          unit: 'celsius',
-          value: '8'
-        }
+        from: new Date('2022-11-05T23:00:00.000Z'),
+        to: new Date('2022-11-06T00:00:00.000Z'),
+        number: 35,
+        symbol: 'cloudy',
+        precipitation: 0,
+        windDirection: 198.2,
+        windSpeed: 7.1,
+        temperature: 10.3,
+        pressure: 1013.1
       }),
       new t.Period({
-        number: 1,
-        symbol: {
-          name: 'Cloudy'
-        },
-        temperature: {
-          unit: 'celsius',
-          value: '9'
-        }
+        from: new Date('2022-11-06T00:00:00.000Z'),
+        to: new Date('2022-11-06T01:00:00.000Z'),
+        number: 36,
+        symbol: 'partlycloudy_night',
+        precipitation: 0,
+        windDirection: 197,
+        windSpeed: 7.2,
+        temperature: 10.3,
+        pressure: 1012.6
       }),
       new t.Period({
-        number: 2,
-        symbol: {
-          name: 'Sunny'
-        },
-        temperature: {
-          unit: 'celsius',
-          value: '10'
-        }
+        from: new Date('2022-11-06T01:00:00.000Z'),
+        to: new Date('2022-11-06T02:00:00.000Z'),
+        number: 37,
+        symbol: 'cloudy',
+        precipitation: 0,
+        windDirection: 197.4,
+        windSpeed: 7.2,
+        temperature: 10.2,
+        pressure: 1012.1
       }),
       new t.Period({
-        number: 3,
-        symbol: {
-          name: 'Cloudy'
-        },
-        temperature: {
-          unit: 'celsius',
-          value: '11'
-        }
+        from: new Date('2022-11-06T02:00:00.000Z'),
+        to: new Date('2022-11-06T03:00:00.000Z'),
+        number: 38,
+        symbol: 'cloudy',
+        precipitation: 0,
+        windDirection: 195.5,
+        windSpeed: 7.2,
+        temperature: 10.1,
+        pressure: 1011.7
+      }),
+      new t.Period({
+        from: new Date('2022-11-06T03:00:00.000Z'),
+        to: new Date('2022-11-06T04:00:00.000Z'),
+        number: 39,
+        symbol: 'partlycloudy_night',
+        precipitation: 0,
+        windDirection: 194.8,
+        windSpeed: 6.8,
+        temperature: 10.2,
+        pressure: 1011
+      }),
+      new t.Period({
+        from: new Date('2022-11-06T04:00:00.000Z'),
+        to: new Date('2022-11-06T05:00:00.000Z'),
+        number: 40,
+        symbol: 'cloudy',
+        precipitation: 0,
+        windDirection: 193.4,
+        windSpeed: 6.5,
+        temperature: 10.2,
+        pressure: 1010.4
+      }),
+      new t.Period({
+        from: new Date('2022-11-06T05:00:00.000Z'),
+        to: new Date('2022-11-06T06:00:00.000Z'),
+        number: 41,
+        symbol: 'cloudy',
+        precipitation: 0,
+        windDirection: 191.5,
+        windSpeed: 6.7,
+        temperature: 10.7,
+        pressure: 1009.7
+      }),
+      new t.Period({
+        from: new Date('2022-11-06T06:00:00.000Z'),
+        to: new Date('2022-11-06T07:00:00.000Z'),
+        number: 42,
+        symbol: 'lightrain',
+        precipitation: 0.1,
+        windDirection: 191.8,
+        windSpeed: 6.8,
+        temperature: 10.6,
+        pressure: 1009.3
+      }),
+      new t.Period({
+        from: new Date('2022-11-06T07:00:00.000Z'),
+        to: new Date('2022-11-06T08:00:00.000Z'),
+        number: 43,
+        symbol: 'cloudy',
+        precipitation: 0,
+        windDirection: 189.6,
+        windSpeed: 6.8,
+        temperature: 10.5,
+        pressure: 1009
+      }),
+      new t.Period({
+        from: new Date('2022-11-06T08:00:00.000Z'),
+        to: new Date('2022-11-06T09:00:00.000Z'),
+        number: 44,
+        symbol: 'rain',
+        precipitation: 0.3,
+        windDirection: 189.4,
+        windSpeed: 7,
+        temperature: 10.9,
+        pressure: 1008.7
+      }),
+      new t.Period({
+        from: new Date('2022-11-06T09:00:00.000Z'),
+        to: new Date('2022-11-06T10:00:00.000Z'),
+        number: 45,
+        symbol: 'heavyrain',
+        precipitation: 1.6,
+        windDirection: 188.4,
+        windSpeed: 6.7,
+        temperature: 11.1,
+        pressure: 1008
+      }),
+      new t.Period({
+        from: new Date('2022-11-06T10:00:00.000Z'),
+        to: new Date('2022-11-06T11:00:00.000Z'),
+        number: 46,
+        symbol: 'heavyrain',
+        precipitation: 2.2,
+        windDirection: 190.1,
+        windSpeed: 6.8,
+        temperature: 10.7,
+        pressure: 1007.7
+      }),
+      new t.Period({
+        from: new Date('2022-11-06T11:00:00.000Z'),
+        to: new Date('2022-11-06T12:00:00.000Z'),
+        number: 47,
+        symbol: 'heavyrain',
+        precipitation: 3.1,
+        windDirection: 188.3,
+        windSpeed: 7.2,
+        temperature: 10.6,
+        pressure: 1007.1
+      }),
+      new t.Period({
+        from: new Date('2022-11-06T12:00:00.000Z'),
+        to: new Date('2022-11-06T13:00:00.000Z'),
+        number: 48,
+        symbol: 'heavyrain',
+        precipitation: 2.7,
+        windDirection: 186.8,
+        windSpeed: 7.1,
+        temperature: 10.6,
+        pressure: 1005.9
+      }),
+      new t.Period({
+        from: new Date('2022-11-06T13:00:00.000Z'),
+        to: new Date('2022-11-06T14:00:00.000Z'),
+        number: 49,
+        symbol: 'heavyrain',
+        precipitation: 2.3,
+        windDirection: 186.3,
+        windSpeed: 7.6,
+        temperature: 10.5,
+        pressure: 1005.1
+      }),
+      new t.Period({
+        from: new Date('2022-11-06T14:00:00.000Z'),
+        to: new Date('2022-11-06T15:00:00.000Z'),
+        number: 50,
+        symbol: 'rain',
+        precipitation: 0.6,
+        windDirection: 183.2,
+        windSpeed: 7.7,
+        temperature: 10.2,
+        pressure: 1004.1
+      }),
+      new t.Period({
+        from: new Date('2022-11-06T15:00:00.000Z'),
+        to: new Date('2022-11-06T16:00:00.000Z'),
+        number: 51,
+        symbol: 'rain',
+        precipitation: 0.5,
+        windDirection: 186.7,
+        windSpeed: 8.2,
+        temperature: 10.2,
+        pressure: 1003.4
+      }),
+      new t.Period({
+        from: new Date('2022-11-06T16:00:00.000Z'),
+        to: new Date('2022-11-06T17:00:00.000Z'),
+        number: 52,
+        symbol: 'rain',
+        precipitation: 0.3,
+        windDirection: 189.9,
+        windSpeed: 8.3,
+        temperature: 10.2,
+        pressure: 1003.1
+      }),
+      new t.Period({
+        from: new Date('2022-11-06T17:00:00.000Z'),
+        to: new Date('2022-11-06T18:00:00.000Z'),
+        number: 53,
+        symbol: 'lightrain',
+        precipitation: 0.2,
+        windDirection: 195.7,
+        windSpeed: 8.5,
+        temperature: 10.5,
+        pressure: 1002.8
+      }),
+      new t.Period({
+        from: new Date('2022-11-06T18:00:00.000Z'),
+        to: new Date('2022-11-06T19:00:00.000Z'),
+        number: 54,
+        symbol: 'cloudy',
+        precipitation: 0,
+        windDirection: 202.3,
+        windSpeed: 8.7,
+        temperature: 10.7,
+        pressure: 1002.8
+      }),
+      new t.Period({
+        from: new Date('2022-11-06T19:00:00.000Z'),
+        to: new Date('2022-11-06T20:00:00.000Z'),
+        number: 55,
+        symbol: 'partlycloudy_night',
+        precipitation: 0,
+        windDirection: 218.4,
+        windSpeed: 8.4,
+        temperature: 11.5,
+        pressure: 1003.3
+      }),
+      new t.Period({
+        from: new Date('2022-11-06T20:00:00.000Z'),
+        to: new Date('2022-11-06T21:00:00.000Z'),
+        number: 56,
+        symbol: 'partlycloudy_night',
+        precipitation: 0,
+        windDirection: 229.5,
+        windSpeed: 8.2,
+        temperature: 11.4,
+        pressure: 1004.1
+      }),
+      new t.Period({
+        from: new Date('2022-11-06T21:00:00.000Z'),
+        to: new Date('2022-11-06T22:00:00.000Z'),
+        number: 57,
+        symbol: 'cloudy',
+        precipitation: 0,
+        windDirection: 220.2,
+        windSpeed: 7.5,
+        temperature: 11.3,
+        pressure: 1004.5
+      }),
+      new t.Period({
+        from: new Date('2022-11-06T22:00:00.000Z'),
+        to: new Date('2022-11-06T23:00:00.000Z'),
+        number: 58,
+        symbol: 'partlycloudy_night',
+        precipitation: 0,
+        windDirection: 224.7,
+        windSpeed: 8.4,
+        temperature: 11.1,
+        pressure: 1005.3
       })
     ]),
-    new t.Day('2018-12-03', [
+    new t.Day(7, [
       new t.Period({
-        number: 0,
-        symbol: {
-          name: 'Rain'
-        },
-        temperature: {
-          unit: 'celsius',
-          value: '8'
-        }
+        from: new Date('2022-11-06T23:00:00.000Z'),
+        to: new Date('2022-11-07T00:00:00.000Z'),
+        number: 59,
+        symbol: 'partlycloudy_night',
+        precipitation: 0,
+        windDirection: 225.9,
+        windSpeed: 8.3,
+        temperature: 11.4,
+        pressure: 1005.9
       }),
       new t.Period({
-        number: 1,
-        symbol: {
-          name: 'Cloudy'
-        },
-        temperature: {
-          unit: 'celsius',
-          value: '9'
-        }
+        from: new Date('2022-11-07T00:00:00.000Z'),
+        to: new Date('2022-11-07T01:00:00.000Z'),
+        number: 60,
+        symbol: 'lightrainshowers_night',
+        precipitation: 0.1,
+        windDirection: 226.4,
+        windSpeed: 8.1,
+        temperature: 11.3,
+        pressure: 1006.4
       }),
       new t.Period({
-        number: 2,
-        symbol: {
-          name: 'Sunny'
-        },
-        temperature: {
-          unit: 'celsius',
-          value: '10'
-        }
+        from: new Date('2022-11-07T01:00:00.000Z'),
+        to: new Date('2022-11-07T02:00:00.000Z'),
+        number: 61,
+        symbol: 'cloudy',
+        precipitation: 0,
+        windDirection: 226.1,
+        windSpeed: 8.1,
+        temperature: 11.3,
+        pressure: 1006.8
       }),
       new t.Period({
-        number: 3,
-        symbol: {
-          name: 'Cloudy'
-        },
-        temperature: {
-          unit: 'celsius',
-          value: '11'
-        }
+        from: new Date('2022-11-07T02:00:00.000Z'),
+        to: new Date('2022-11-07T03:00:00.000Z'),
+        number: 62,
+        symbol: 'partlycloudy_night',
+        precipitation: 0,
+        windDirection: 220.9,
+        windSpeed: 7.7,
+        temperature: 11.3,
+        pressure: 1007
+      }),
+      new t.Period({
+        from: new Date('2022-11-07T03:00:00.000Z'),
+        to: new Date('2022-11-07T04:00:00.000Z'),
+        number: 63,
+        symbol: 'lightrain',
+        precipitation: 0.2,
+        windDirection: 218.5,
+        windSpeed: 7.4,
+        temperature: 11.1,
+        pressure: 1007.1
+      }),
+      new t.Period({
+        from: new Date('2022-11-07T04:00:00.000Z'),
+        to: new Date('2022-11-07T05:00:00.000Z'),
+        number: 64,
+        symbol: 'rain',
+        precipitation: 0.3,
+        windDirection: 214.9,
+        windSpeed: 7,
+        temperature: 11.1,
+        pressure: 1007.2
+      }),
+      new t.Period({
+        from: new Date('2022-11-07T05:00:00.000Z'),
+        to: new Date('2022-11-07T06:00:00.000Z'),
+        number: 65,
+        symbol: 'rain',
+        precipitation: 0.9,
+        windDirection: 213.8,
+        windSpeed: 7.7,
+        temperature: 11.3,
+        pressure: 1007.4
+      }),
+      new t.Period({
+        from: new Date('2022-11-07T06:00:00.000Z'),
+        to: new Date('2022-11-07T07:00:00.000Z'),
+        number: 66,
+        symbol: 'cloudy',
+        precipitation: 0.2,
+        windDirection: 211.7,
+        windSpeed: 7.4,
+        temperature: 11.2,
+        pressure: 1007.8
+      }),
+      new t.Period({
+        from: new Date('2022-11-07T12:00:00.000Z'),
+        to: new Date('2022-11-07T13:00:00.000Z'),
+        number: 67,
+        symbol: 'cloudy',
+        precipitation: 0,
+        windDirection: 212.5,
+        windSpeed: 7,
+        temperature: 14.3,
+        pressure: 1009.9
+      }),
+      new t.Period({
+        from: new Date('2022-11-07T18:00:00.000Z'),
+        to: new Date('2022-11-07T19:00:00.000Z'),
+        number: 68,
+        symbol: 'cloudy',
+        precipitation: 0,
+        windDirection: 192.6,
+        windSpeed: 6.5,
+        temperature: 14.3,
+        pressure: 1011
+      })
+    ]),
+    new t.Day(8, [
+      new t.Period({
+        from: new Date('2022-11-08T00:00:00.000Z'),
+        to: new Date('2022-11-08T01:00:00.000Z'),
+        number: 69,
+        symbol: 'cloudy',
+        precipitation: 0,
+        windDirection: 183,
+        windSpeed: 5.9,
+        temperature: 11.7,
+        pressure: 1008.8
+      }),
+      new t.Period({
+        from: new Date('2022-11-08T06:00:00.000Z'),
+        to: new Date('2022-11-08T07:00:00.000Z'),
+        number: 70,
+        symbol: 'cloudy',
+        precipitation: 0.4,
+        windDirection: 176.4,
+        windSpeed: 6.9,
+        temperature: 13.4,
+        pressure: 1003.5
+      }),
+      new t.Period({
+        from: new Date('2022-11-08T12:00:00.000Z'),
+        to: new Date('2022-11-08T13:00:00.000Z'),
+        number: 71,
+        symbol: 'lightrain',
+        precipitation: 0.6,
+        windDirection: 220,
+        windSpeed: 9.2,
+        temperature: 16,
+        pressure: 1003.4
+      }),
+      new t.Period({
+        from: new Date('2022-11-08T18:00:00.000Z'),
+        to: new Date('2022-11-08T19:00:00.000Z'),
+        number: 72,
+        symbol: 'cloudy',
+        precipitation: 0,
+        windDirection: 220.1,
+        windSpeed: 5,
+        temperature: 13.3,
+        pressure: 1005.9
       })
     ])
   ];
@@ -484,11 +1070,11 @@ describe('WeatherForecast', function () {
     const signal = app.generateSignal(days);
     assert(signal);
     assert(signal.name.includes(cityName));
-    assert(signal.message.includes("\nOvernight: Rain, 8°C\n"));
-    assert(signal.message.includes("\Morning: Cloudy, 9°C\n"));
-    assert(signal.message.includes("\nAfternoon: Sunny, 10°C\n"));
-    assert(signal.message.includes("\nEvening: Cloudy, 11°C"));
-
+    assert(signal.message.includes("<strong>4:</strong>"));
+    assert(signal.message.includes("\n14:00 cloudy, 11.6°C\n"));
+    assert(signal.message.includes("\n17:00 partlycloudy_night, 10.9°C\n"));
+    assert(signal.message.includes("\n20:00 partlycloudy_night, 8.8°C\n"));
+    assert(signal.message.includes("\n23:00 partlycloudy_night, 7.8°C\n"));
   });
 
   it('#generateSignal(days) with imperial units', function () {
@@ -497,15 +1083,15 @@ describe('WeatherForecast', function () {
     const signal = app.generateSignal(days);
     assert(signal);
     assert(signal.name.includes(cityName));
-    assert(signal.message.includes("\nOvernight: Rain, 46°F\n"));
-    assert(signal.message.includes("\Morning: Cloudy, 48°F\n"));
-    assert(signal.message.includes("\nAfternoon: Sunny, 50°F\n"));
-    assert(signal.message.includes("\nEvening: Cloudy, 52°F"));
-
+    assert(signal.message.includes("<strong>4:</strong>"));
+    assert(signal.message.includes("\n14:00 cloudy, 53°F\n"));
+    assert(signal.message.includes("\n17:00 partlycloudy_night, 52°F\n"));
+    assert(signal.message.includes("\n20:00 partlycloudy_night, 48°F\n"));
+    assert(signal.message.includes("\n23:00 partlycloudy_night, 46°F\n"));
   });
 
   describe('options', function () {
-    const app = buildApp();    
+    const app = buildApp();
     it('retrieves a full set of options', function () {
       return app.options('cityId').then(options => {
         assert.ok(options);
@@ -514,7 +1100,7 @@ describe('WeatherForecast', function () {
       })
     });
 
-    it ('ignores whitespace search', function () {
+    it('ignores whitespace search', function () {
       return app.options('cityId', '  ').then(options => {
         assert.ok(options);
         assert.ok(options.length);
@@ -522,7 +1108,7 @@ describe('WeatherForecast', function () {
       })
     });
 
-    it ('returns 20 results on vague search', function () {
+    it('returns 20 results on vague search', function () {
       return app.options('cityId', 'a').then(options => {
         assert.ok(options);
         assert.ok(options.length);
@@ -530,7 +1116,7 @@ describe('WeatherForecast', function () {
       })
     });
 
-    it ('returns results matching the search', function () {
+    it('returns results matching the search', function () {
       return app.options('cityId', 'texas').then(options => {
         assert.ok(options);
         assert.ok(options.length);
@@ -538,13 +1124,12 @@ describe('WeatherForecast', function () {
       })
     });
 
-    it ('returns results matching the search', function () {
+    it('returns results matching the search', function () {
       return app.options('cityId', 'austin').then(options => {
         assert.ok(options);
         assert.ok(options.length);
         assert.equal(1, options.length);
-        assert(options[0].key.toLowerCase().includes('austin'));
-        assert.equal('http://www.yr.no/place/United_States/Texas/Austin/forecast.xml', options[0].key);
+        assert.equal('https://api.met.no/weatherapi/locationforecast/2.0/compact?lat=30.26715&lon=-97.74306', options[0].key);
       })
     });
 
@@ -556,14 +1141,14 @@ describe('WeatherForecast', function () {
       })
     });
   })
-  
-  
+
+
   it('#run()', async function () {
-    const app = buildApp();    
+    const app = buildApp();
     return app.run().then((signal) => {
       assert.ok(signal);
       assert(signal.name.includes(cityName));
-      assert(signal.message.includes('Overnight:'));
+      assert(signal.message.includes('Fri Nov 04 2022'));
     });
   });
 
@@ -576,8 +1161,8 @@ describe('WeatherForecast', function () {
       const option = options[0];
       assert.ok(option.key);
       assert.ok(option.value);
-      assert(option.key.toLowerCase().includes('vella'));
-      assert(option.key.toLowerCase().includes('.xml'));
+      assert(option.key.toLowerCase().includes('lat=42.50779&lon=1.52109'));
+      assert(option.key.toLowerCase().includes('locationforecast/2.0/compact'));
       assert(option.value.toLowerCase().includes('vella'));
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,21 +4,67 @@
 
 "@dabh/diagnostics@^2.0.2":
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@dabh/diagnostics/-/diagnostics-2.0.2.tgz#290d08f7b381b8f94607dc8f471a12c675f9db31"
+  resolved "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz"
   integrity sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==
   dependencies:
     colorspace "1.1.x"
     enabled "2.0.x"
     kuler "^2.0.0"
 
+"@sindresorhus/is@^4.0.0":
+  version "4.6.0"
+  resolved "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz"
+  integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
+
+"@szmarczak/http-timer@^4.0.5":
+  version "4.0.6"
+  resolved "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz"
+  integrity sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==
+  dependencies:
+    defer-to-connect "^2.0.0"
+
+"@types/cacheable-request@^6.0.1":
+  version "6.0.2"
+  resolved "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz"
+  integrity sha512-B3xVo+dlKM6nnKTcmm5ZtY/OL8bOAOd2Olee9M1zft65ox50OzjEHW91sDiU9j6cvW8Ejg1/Qkf4xd2kugApUA==
+  dependencies:
+    "@types/http-cache-semantics" "*"
+    "@types/keyv" "*"
+    "@types/node" "*"
+    "@types/responselike" "*"
+
+"@types/http-cache-semantics@*":
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz"
+  integrity sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==
+
+"@types/keyv@*":
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/@types/keyv/-/keyv-4.2.0.tgz"
+  integrity sha512-xoBtGl5R9jeKUhc8ZqeYaRDx04qqJ10yhhXYGmJ4Jr8qKpvMsDQQrNUvF/wUJ4klOtmJeJM+p2Xo3zp9uaC3tw==
+  dependencies:
+    keyv "*"
+
+"@types/node@*":
+  version "18.11.7"
+  resolved "https://registry.npmjs.org/@types/node/-/node-18.11.7.tgz"
+  integrity sha512-LhFTglglr63mNXUSRYD8A+ZAIu5sFqNJ4Y2fPuY7UlrySJH87rRRlhtVmMHplmfk5WkoJGmDjE9oiTfyX94CpQ==
+
+"@types/responselike@*", "@types/responselike@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz"
+  integrity sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==
+  dependencies:
+    "@types/node" "*"
+
 "@ungap/promise-all-settled@1.1.2":
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
+  resolved "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
 ajv@^6.12.3:
   version "6.12.6"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
+  resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
   dependencies:
     fast-deep-equal "^3.1.1"
@@ -28,29 +74,29 @@ ajv@^6.12.3:
 
 ansi-colors@4.1.1:
   version "4.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
+  resolved "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz"
   integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
 
 ansi-regex@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
 ansi-regex@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
+  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
 ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
 
 anymatch@~3.1.1:
   version "3.1.2"
-  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
+  resolved "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz"
   integrity sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==
   dependencies:
     normalize-path "^3.0.0"
@@ -58,66 +104,66 @@ anymatch@~3.1.1:
 
 argparse@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 asn1@~0.2.3:
   version "0.2.4"
-  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
+  resolved "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz"
   integrity sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==
   dependencies:
     safer-buffer "~2.1.0"
 
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
+  resolved "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
 async@^3.1.0:
   version "3.2.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720"
+  resolved "https://registry.npmjs.org/async/-/async-3.2.0.tgz"
   integrity sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==
 
 asynckit@^0.4.0:
   version "0.4.0"
-  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
 aws-sign2@~0.7.0:
   version "0.7.0"
-  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
+  resolved "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz"
   integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
 
 aws4@^1.8.0:
   version "1.11.0"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
+  resolved "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
 balanced-match@^1.0.0:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
+  resolved "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz"
   integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
 
 binary-extensions@^2.0.0:
   version "2.2.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
+  resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
 bluebird@^3.5.0:
   version "3.7.2"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
+  resolved "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz"
   integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
   dependencies:
     balanced-match "^1.0.0"
@@ -125,29 +171,47 @@ brace-expansion@^1.1.7:
 
 braces@~3.0.2:
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
+  resolved "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
 
 browser-stdout@1.3.1:
   version "1.3.1"
-  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
+  resolved "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
+
+cacheable-lookup@^5.0.3:
+  version "5.0.4"
+  resolved "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz"
+  integrity sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==
+
+cacheable-request@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz"
+  integrity sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==
+  dependencies:
+    clone-response "^1.0.2"
+    get-stream "^5.1.0"
+    http-cache-semantics "^4.0.0"
+    keyv "^4.0.0"
+    lowercase-keys "^2.0.0"
+    normalize-url "^6.0.1"
+    responselike "^2.0.0"
 
 camelcase@^6.0.0:
   version "6.2.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
+  resolved "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caseless@~0.12.0:
   version "0.12.0"
-  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
+  resolved "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
 chalk@^4.0.0:
   version "4.1.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz"
   integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
   dependencies:
     ansi-styles "^4.1.0"
@@ -155,7 +219,7 @@ chalk@^4.0.0:
 
 chokidar@3.5.1:
   version "3.5.1"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
+  resolved "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz"
   integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
   dependencies:
     anymatch "~3.1.1"
@@ -170,40 +234,47 @@ chokidar@3.5.1:
 
 cliui@^7.0.2:
   version "7.0.4"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  resolved "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz"
   integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
   dependencies:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
+clone-response@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz"
+  integrity sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==
+  dependencies:
+    mimic-response "^1.0.0"
+
 color-convert@^1.9.1:
   version "1.9.3"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
+  resolved "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
   dependencies:
     color-name "1.1.3"
 
 color-convert@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  resolved "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz"
   integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
   dependencies:
     color-name "~1.1.4"
 
 color-name@1.1.3:
   version "1.1.3"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
 color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 color-string@^1.5.2:
   version "1.5.5"
-  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.5.5.tgz#65474a8f0e7439625f3d27a6a19d89fc45223014"
+  resolved "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz"
   integrity sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==
   dependencies:
     color-name "^1.0.0"
@@ -211,7 +282,7 @@ color-string@^1.5.2:
 
 color@3.0.x:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/color/-/color-3.0.0.tgz#d920b4328d534a3ac8295d68f7bd4ba6c427be9a"
+  resolved "https://registry.npmjs.org/color/-/color-3.0.0.tgz"
   integrity sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==
   dependencies:
     color-convert "^1.9.1"
@@ -219,12 +290,12 @@ color@3.0.x:
 
 colors@^1.2.1:
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  resolved "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
 colorspace@1.1.x:
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/colorspace/-/colorspace-1.1.2.tgz#e0128950d082b86a2168580796a0aa5d6c68d8c5"
+  resolved "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz"
   integrity sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==
   dependencies:
     color "3.0.x"
@@ -232,31 +303,31 @@ colorspace@1.1.x:
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  resolved "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
 
 concat-map@0.0.1:
   version "0.0.1"
-  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+  resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
 dashdash@^1.12.0:
   version "1.14.1"
-  resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
+  resolved "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
   integrity sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=
   dependencies:
     assert-plus "^1.0.0"
 
 daskeyboard-applet@2.11.3:
   version "2.11.3"
-  resolved "https://registry.yarnpkg.com/daskeyboard-applet/-/daskeyboard-applet-2.11.3.tgz#53fa71b81264148d5ab018a54424924bd13898b3"
+  resolved "https://registry.npmjs.org/daskeyboard-applet/-/daskeyboard-applet-2.11.3.tgz"
   integrity sha512-un5uL9QnCBlaLqhF5SJsY2o0F4KJJeBonP0sxdySsXfoLgRNYS2Ywz539f2647992bqVp7GtVDSCY6LsTuBtiw==
   dependencies:
     moment "^2.22.2"
@@ -267,29 +338,41 @@ daskeyboard-applet@2.11.3:
 
 debug@4.3.1:
   version "4.3.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
   dependencies:
     ms "2.1.2"
 
 decamelize@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
+  resolved "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz"
   integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
+
+decompress-response@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz"
+  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
+  dependencies:
+    mimic-response "^3.1.0"
+
+defer-to-connect@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz"
+  integrity sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==
 
 delayed-stream@~1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
 diff@5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
+  resolved "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz"
   integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
-  resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
+  resolved "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz"
   integrity sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=
   dependencies:
     jsbn "~0.1.0"
@@ -297,69 +380,76 @@ ecc-jsbn@~0.1.1:
 
 emoji-regex@^8.0.0:
   version "8.0.0"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
 enabled@2.0.x:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/enabled/-/enabled-2.0.0.tgz#f9dd92ec2d6f4bbc0d5d1e64e21d61cd4665e7c2"
+  resolved "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz"
   integrity sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==
+
+end-of-stream@^1.1.0:
+  version "1.4.4"
+  resolved "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz"
+  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
+  dependencies:
+    once "^1.4.0"
 
 escalade@^3.1.1:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
+  resolved "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
 escape-string-regexp@4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 extend@~3.0.2:
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  resolved "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
 extsprintf@1.3.0:
   version "1.3.0"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
+  resolved "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
   integrity sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=
 
 extsprintf@^1.2.0:
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
+  resolved "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.0.tgz"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
 fast-deep-equal@^3.1.1:
   version "3.1.3"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
+  resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
 fast-safe-stringify@^2.0.4:
   version "2.0.7"
-  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
+  resolved "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz"
   integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
 
 fecha@^4.2.0:
   version "4.2.1"
-  resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.1.tgz#0a83ad8f86ef62a091e22bb5a039cd03d23eecce"
+  resolved "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz"
   integrity sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q==
 
 fill-range@^7.0.1:
   version "7.0.1"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
+  resolved "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz"
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
 
 find-up@5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  resolved "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz"
   integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
   dependencies:
     locate-path "^6.0.0"
@@ -367,22 +457,22 @@ find-up@5.0.0:
 
 flat@^5.0.2:
   version "5.0.2"
-  resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
+  resolved "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
 fn.name@1.x.x:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
+  resolved "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
 forever-agent@~0.6.1:
   version "0.6.1"
-  resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
+  resolved "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
 form-data@~2.3.2:
   version "2.3.3"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
+  resolved "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz"
   integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
   dependencies:
     asynckit "^0.4.0"
@@ -391,7 +481,7 @@ form-data@~2.3.2:
 
 fs.realpath@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
 fsevents@~2.3.1:
@@ -401,26 +491,33 @@ fsevents@~2.3.1:
 
 get-caller-file@^2.0.5:
   version "2.0.5"
-  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
+get-stream@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz"
+  integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
+  dependencies:
+    pump "^3.0.0"
 
 getpass@^0.1.1:
   version "0.1.7"
-  resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
+  resolved "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz"
   integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
   dependencies:
     assert-plus "^1.0.0"
 
 glob-parent@~5.1.0:
   version "5.1.2"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
 
 glob@7.1.6:
   version "7.1.6"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  resolved "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
     fs.realpath "^1.0.0"
@@ -430,24 +527,41 @@ glob@7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+got@^11.8.3:
+  version "11.8.3"
+  resolved "https://registry.npmjs.org/got/-/got-11.8.3.tgz"
+  integrity sha512-7gtQ5KiPh1RtGS9/Jbv1ofDpBFuq42gyfEib+ejaRBJuj/3tQFeR5+gw57e4ipaU8c/rCjvX6fkQz2lyDlGAOg==
+  dependencies:
+    "@sindresorhus/is" "^4.0.0"
+    "@szmarczak/http-timer" "^4.0.5"
+    "@types/cacheable-request" "^6.0.1"
+    "@types/responselike" "^1.0.0"
+    cacheable-lookup "^5.0.3"
+    cacheable-request "^7.0.2"
+    decompress-response "^6.0.0"
+    http2-wrapper "^1.0.0-beta.5.2"
+    lowercase-keys "^2.0.0"
+    p-cancelable "^2.0.0"
+    responselike "^2.0.0"
+
 graceful-fs@^4.1.11:
   version "4.2.6"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
+  resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
 
 growl@1.10.5:
   version "1.10.5"
-  resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
+  resolved "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz"
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
 
 har-schema@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
+  resolved "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz"
   integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
 
 har-validator@~5.1.3:
   version "5.1.5"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.5.tgz#1f0803b9f8cb20c0fa13822df1ecddb36bde1efd"
+  resolved "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz"
   integrity sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==
   dependencies:
     ajv "^6.12.3"
@@ -455,31 +569,44 @@ har-validator@~5.1.3:
 
 has-flag@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  resolved "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
 he@1.2.0:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  resolved "https://registry.npmjs.org/he/-/he-1.2.0.tgz"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+http-cache-semantics@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz"
+  integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
 
 http-signature@~1.2.0:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
+  resolved "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz"
   integrity sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=
   dependencies:
     assert-plus "^1.0.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+http2-wrapper@^1.0.0-beta.5.2:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz"
+  integrity sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==
+  dependencies:
+    quick-lru "^5.1.1"
+    resolve-alpn "^1.0.0"
+
 imurmurhash@^0.1.4:
   version "0.1.4"
-  resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+  resolved "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
 inflight@^1.0.4:
   version "1.0.6"
-  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  resolved "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
   integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
   dependencies:
     once "^1.3.0"
@@ -487,108 +614,113 @@ inflight@^1.0.4:
 
 inherits@2, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.4"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 is-arrayish@^0.3.1:
   version "0.3.2"
-  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  resolved "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz"
   integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
 is-binary-path@~2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  resolved "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz"
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
 
 is-extglob@^2.1.1:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+  resolved "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
   integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
 
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+  resolved "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
 
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  resolved "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
 is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.1"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
+  resolved "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
   dependencies:
     is-extglob "^2.1.1"
 
 is-number@^7.0.0:
   version "7.0.0"
-  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
+  resolved "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
 is-plain-obj@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
+  resolved "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz"
   integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
 
 is-stream@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
+  resolved "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz"
   integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
 
 is-typedarray@~1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
+  resolved "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
 isarray@~1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  resolved "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
 isexe@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
 isstream@~0.1.2:
   version "0.1.2"
-  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+  resolved "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
 js-yaml@4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.0.0.tgz#f426bc0ff4b4051926cd588c71113183409a121f"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz"
   integrity sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==
   dependencies:
     argparse "^2.0.1"
 
 jsbn@~0.1.0:
   version "0.1.1"
-  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+  resolved "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
+
+json-buffer@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz"
+  integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
-  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+  resolved "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
 json-schema@0.2.3:
   version "0.2.3"
-  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
+  resolved "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
   integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
 
 json-stringify-safe@~5.0.1:
   version "5.0.1"
-  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
+  resolved "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
 jsprim@^1.2.2:
   version "1.4.1"
-  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
+  resolved "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz"
   integrity sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=
   dependencies:
     assert-plus "1.0.0"
@@ -596,33 +728,40 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+keyv@*, keyv@^4.0.0:
+  version "4.5.0"
+  resolved "https://registry.npmjs.org/keyv/-/keyv-4.5.0.tgz"
+  integrity sha512-2YvuMsA+jnFGtBareKqgANOEKe1mk3HKiXu2fRmAfyxG0MJAywNhi5ttWA3PMjl4NmpyjZNbFifR2vNjW1znfA==
+  dependencies:
+    json-buffer "3.0.1"
+
 kuler@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/kuler/-/kuler-2.0.0.tgz#e2c570a3800388fb44407e851531c1d670b061b3"
+  resolved "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz"
   integrity sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==
 
 locate-path@^6.0.0:
   version "6.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  resolved "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz"
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
 
 lodash@^4.17.19:
   version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.0.0.tgz#69b3cc46d20f448eccdb75ea1fa733d9e821c920"
+  resolved "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz"
   integrity sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==
   dependencies:
     chalk "^4.0.0"
 
 logform@^2.2.0:
   version "2.2.0"
-  resolved "https://registry.yarnpkg.com/logform/-/logform-2.2.0.tgz#40f036d19161fc76b68ab50fdc7fe495544492f2"
+  resolved "https://registry.npmjs.org/logform/-/logform-2.2.0.tgz"
   integrity sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==
   dependencies:
     colors "^1.2.1"
@@ -631,28 +770,43 @@ logform@^2.2.0:
     ms "^2.1.1"
     triple-beam "^1.3.0"
 
+lowercase-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz"
+  integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
+
 mime-db@1.47.0:
   version "1.47.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.47.0.tgz#8cb313e59965d3c05cfbf898915a267af46a335c"
+  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz"
   integrity sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==
 
 mime-types@^2.1.12, mime-types@~2.1.19:
   version "2.1.30"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.30.tgz#6e7be8b4c479825f85ed6326695db73f9305d62d"
+  resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz"
   integrity sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==
   dependencies:
     mime-db "1.47.0"
 
+mimic-response@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz"
+  integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
+
+mimic-response@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz"
+  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
+
 minimatch@3.0.4, minimatch@^3.0.4:
   version "3.0.4"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
     brace-expansion "^1.1.7"
 
 mocha@^8.3.2:
   version "8.3.2"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-8.3.2.tgz#53406f195fa86fbdebe71f8b1c6fb23221d69fcc"
+  resolved "https://registry.npmjs.org/mocha/-/mocha-8.3.2.tgz"
   integrity sha512-UdmISwr/5w+uXLPKspgoV7/RXZwKRTiTjJ2/AC5ZiEztIoOYdfKb19+9jNmEInzx5pBsCyJQzarAxqIGBNYJhg==
   dependencies:
     "@ungap/promise-all-settled" "1.1.2"
@@ -683,119 +837,142 @@ mocha@^8.3.2:
 
 moment@^2.22.2:
   version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  resolved "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
 ms@2.1.2:
   version "2.1.2"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
 ms@2.1.3, ms@^2.1.1:
   version "2.1.3"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 nanoid@3.1.20:
   version "3.1.20"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.20.tgz#badc263c6b1dcf14b71efaa85f6ab4c1d6cfc788"
+  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz"
   integrity sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==
 
 node-localstorage@^1.3.1:
   version "1.3.1"
-  resolved "https://registry.yarnpkg.com/node-localstorage/-/node-localstorage-1.3.1.tgz#3177ef42837f398aee5dd75e319b281e40704243"
+  resolved "https://registry.npmjs.org/node-localstorage/-/node-localstorage-1.3.1.tgz"
   integrity sha512-NMWCSWWc6JbHT5PyWlNT2i8r7PgGYXVntmKawY83k/M0UJScZ5jirb61TLnqKwd815DfBQu+lR3sRw08SPzIaQ==
   dependencies:
     write-file-atomic "^1.1.4"
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
+  resolved "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+
+normalize-url@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz"
+  integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
 
 oauth-sign@~0.9.0:
   version "0.9.0"
-  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
+  resolved "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-once@^1.3.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  resolved "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
 
 one-time@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/one-time/-/one-time-1.0.0.tgz#e06bc174aed214ed58edede573b433bbf827cb45"
+  resolved "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz"
   integrity sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==
   dependencies:
     fn.name "1.x.x"
 
+p-cancelable@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz"
+  integrity sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==
+
 p-limit@^3.0.2:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+  resolved "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz"
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
   dependencies:
     yocto-queue "^0.1.0"
 
 p-locate@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  resolved "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz"
   integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
   dependencies:
     p-limit "^3.0.2"
 
 path-exists@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
+  resolved "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  resolved "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
 performance-now@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
+  resolved "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
 picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.2.2"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+  resolved "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
 psl@^1.1.28:
   version "1.8.0"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
+  resolved "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz"
   integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
+
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz"
+  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
 
 punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  resolved "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
 qs@~6.5.2:
   version "6.5.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
+  resolved "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+quick-lru@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz"
+  integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
 randombytes@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
+  resolved "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz"
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
   dependencies:
     safe-buffer "^5.1.0"
 
 readable-stream@^2.3.7:
   version "2.3.7"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
+  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
   dependencies:
     core-util-is "~1.0.0"
@@ -808,7 +985,7 @@ readable-stream@^2.3.7:
 
 readable-stream@^3.4.0:
   version "3.6.0"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
   dependencies:
     inherits "^2.0.3"
@@ -817,21 +994,21 @@ readable-stream@^3.4.0:
 
 readdirp@~3.5.0:
   version "3.5.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.5.0.tgz#9ba74c019b15d365278d2e91bb8c48d7b4d42c9e"
+  resolved "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz"
   integrity sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==
   dependencies:
     picomatch "^2.2.1"
 
 request-promise-core@1.1.4:
   version "1.1.4"
-  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.4.tgz#3eedd4223208d419867b78ce815167d10593a22f"
+  resolved "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz"
   integrity sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==
   dependencies:
     lodash "^4.17.19"
 
 request-promise@^4.2.2:
   version "4.2.6"
-  resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-4.2.6.tgz#7e7e5b9578630e6f598e3813c0f8eb342a27f0a2"
+  resolved "https://registry.npmjs.org/request-promise/-/request-promise-4.2.6.tgz"
   integrity sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==
   dependencies:
     bluebird "^3.5.0"
@@ -841,7 +1018,7 @@ request-promise@^4.2.2:
 
 request@^2.88.0:
   version "2.88.2"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
+  resolved "https://registry.npmjs.org/request/-/request-2.88.2.tgz"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
   dependencies:
     aws-sign2 "~0.7.0"
@@ -867,51 +1044,58 @@ request@^2.88.0:
 
 require-directory@^2.1.1:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+  resolved "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
+
+resolve-alpn@^1.0.0:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz"
+  integrity sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==
+
+responselike@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz"
+  integrity sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==
+  dependencies:
+    lowercase-keys "^2.0.0"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
-  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
-
-sax@>=0.6.0:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
-  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
 serialize-javascript@5.0.1:
   version "5.0.1"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-5.0.1.tgz#7886ec848049a462467a97d3d918ebb2aaf934f4"
+  resolved "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz"
   integrity sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==
   dependencies:
     randombytes "^2.1.0"
 
 simple-swizzle@^0.2.2:
   version "0.2.2"
-  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  resolved "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz"
   integrity sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=
   dependencies:
     is-arrayish "^0.3.1"
 
 slide@^1.1.5:
   version "1.1.6"
-  resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
+  resolved "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
   integrity sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=
 
 sshpk@^1.7.0:
   version "1.16.1"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.1.tgz#fb661c0bef29b39db40769ee39fa70093d6f6877"
+  resolved "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz"
   integrity sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==
   dependencies:
     asn1 "~0.2.3"
@@ -926,17 +1110,17 @@ sshpk@^1.7.0:
 
 stack-trace@0.0.x:
   version "0.0.10"
-  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+  resolved "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz"
   integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
 
 stealthy-require@^1.1.1:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
+  resolved "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
 
 "string-width@^1.0.2 || 2":
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz"
   integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
   dependencies:
     is-fullwidth-code-point "^2.0.0"
@@ -944,7 +1128,7 @@ stealthy-require@^1.1.1:
 
 string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.2"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.2.tgz#dafd4f9559a7585cfba529c6a0a4f73488ebd4c5"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz"
   integrity sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==
   dependencies:
     emoji-regex "^8.0.0"
@@ -953,66 +1137,66 @@ string-width@^4.1.0, string-width@^4.2.0:
 
 string_decoder@^1.1.1:
   version "1.3.0"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   dependencies:
     safe-buffer "~5.2.0"
 
 string_decoder@~1.1.1:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
 
 strip-ansi@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
   integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
   dependencies:
     ansi-regex "^3.0.0"
 
 strip-ansi@^6.0.0:
   version "6.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz"
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
 
 strip-json-comments@3.1.1:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
 supports-color@8.1.1:
   version "8.1.1"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
   dependencies:
     has-flag "^4.0.0"
 
 supports-color@^7.1.0:
   version "7.2.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
 
 text-hex@1.0.x:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/text-hex/-/text-hex-1.0.0.tgz#69dc9c1b17446ee79a92bf5b884bb4b9127506f5"
+  resolved "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz"
   integrity sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==
 
 to-regex-range@^5.0.1:
   version "5.0.1"
-  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
+  resolved "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz"
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
 
 tough-cookie@^2.3.3, tough-cookie@~2.5.0:
   version "2.5.0"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
+  resolved "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz"
   integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
   dependencies:
     psl "^1.1.28"
@@ -1020,41 +1204,41 @@ tough-cookie@^2.3.3, tough-cookie@~2.5.0:
 
 triple-beam@^1.2.0, triple-beam@^1.3.0:
   version "1.3.0"
-  resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.3.0.tgz#a595214c7298db8339eeeee083e4d10bd8cb8dd9"
+  resolved "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz"
   integrity sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
-  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  resolved "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
   integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
   dependencies:
     safe-buffer "^5.0.1"
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
-  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
+  resolved "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
 uri-js@^4.2.2:
   version "4.4.1"
-  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
+  resolved "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz"
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
 
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
 uuid@^3.3.2:
   version "3.4.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
+  resolved "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
 verror@1.10.0:
   version "1.10.0"
-  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
+  resolved "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz"
   integrity sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=
   dependencies:
     assert-plus "^1.0.0"
@@ -1063,21 +1247,21 @@ verror@1.10.0:
 
 which@2.0.2:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  resolved "https://registry.npmjs.org/which/-/which-2.0.2.tgz"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
 
 wide-align@1.1.3:
   version "1.1.3"
-  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
+  resolved "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz"
   integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
   dependencies:
     string-width "^1.0.2 || 2"
 
 winston-transport@^4.4.0:
   version "4.4.0"
-  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.4.0.tgz#17af518daa690d5b2ecccaa7acf7b20ca7925e59"
+  resolved "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz"
   integrity sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==
   dependencies:
     readable-stream "^2.3.7"
@@ -1085,7 +1269,7 @@ winston-transport@^4.4.0:
 
 winston@^3.1.0:
   version "3.3.3"
-  resolved "https://registry.yarnpkg.com/winston/-/winston-3.3.3.tgz#ae6172042cafb29786afa3d09c8ff833ab7c9170"
+  resolved "https://registry.npmjs.org/winston/-/winston-3.3.3.tgz"
   integrity sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==
   dependencies:
     "@dabh/diagnostics" "^2.0.2"
@@ -1100,12 +1284,12 @@ winston@^3.1.0:
 
 workerpool@6.1.0:
   version "6.1.0"
-  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.1.0.tgz#a8e038b4c94569596852de7a8ea4228eefdeb37b"
+  resolved "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz"
   integrity sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==
 
 wrap-ansi@^7.0.0:
   version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
@@ -1114,49 +1298,36 @@ wrap-ansi@^7.0.0:
 
 wrappy@1:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
 write-file-atomic@^1.1.4:
   version "1.3.4"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-1.3.4.tgz#f807a4f0b1d9e913ae7a48112e6cc3af1991b45f"
+  resolved "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz"
   integrity sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=
   dependencies:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     slide "^1.1.5"
 
-xml2js@^0.4.19:
-  version "0.4.23"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
-  integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
-  dependencies:
-    sax ">=0.6.0"
-    xmlbuilder "~11.0.0"
-
-xmlbuilder@~11.0.0:
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
-  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
-
 y18n@^5.0.5:
   version "5.0.7"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.7.tgz#0c514aba53fc40e2db911aeb8b51566a3374efe7"
+  resolved "https://registry.npmjs.org/y18n/-/y18n-5.0.7.tgz"
   integrity sha512-oOhslryvNcA1lB9WYr+M6TMyLkLg81Dgmyb48ZDU0lvR+5bmNDTMz7iobM1QXooaLhbbrcHrlNaABhI6Vo6StQ==
 
 yargs-parser@20.2.4:
   version "20.2.4"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz"
   integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
 
 yargs-parser@^20.2.2:
   version "20.2.7"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.7.tgz#61df85c113edfb5a7a4e36eb8aa60ef423cbc90a"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz"
   integrity sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==
 
 yargs-unparser@2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/yargs-unparser/-/yargs-unparser-2.0.0.tgz#f131f9226911ae5d9ad38c432fe809366c2325eb"
+  resolved "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz"
   integrity sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==
   dependencies:
     camelcase "^6.0.0"
@@ -1166,7 +1337,7 @@ yargs-unparser@2.0.0:
 
 yargs@16.2.0:
   version "16.2.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+  resolved "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz"
   integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
   dependencies:
     cliui "^7.0.2"
@@ -1179,5 +1350,5 @@ yargs@16.2.0:
 
 yocto-queue@^0.1.0:
   version "0.1.0"
-  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
+  resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==


### PR DESCRIPTION
This PR fixes #3 (most likely also #8 )

A summary of the changes:

- obviously this update makes the applet support the new yr.no API since the XML based API has been terminated
- version updated to 2.1.0 (minor version update, no new functionality)
- CHANGELOG.md updated
- README.md section added for future maintainers
- cities file transformed to provide correct URL's for the JSON API
- tests adapted to new API results (mainly 24 hours time series vs 4 periods per day)
- color selection algorithm updated:
  - use a collection of 6.00 .. 18.00 hour items from API call result (after 18.00 use first returned item .. 0.00 hours)
  - from the collection select item with most precipitation
  - use the (existing) color selection of the symbol name of the selected item